### PR TITLE
Changed 'addon' to 'plugin'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 # JUnit reporter for QUnit
 
-A QUnit addon that produces JUnit-style XML test reports (e.g. for integration into build tools like Jenkins).
+A QUnit plugin that produces JUnit-style XML test reports (e.g. for integration into build tools like Jenkins).
 
 ## Usage
 
-Include the addon script after QUnit itself, then implement the `jUnitReport` hook to do something with the XML string (e.g. upload it to a server):
+Include the plugin script after QUnit itself, then implement the `jUnitReport` hook to do something with the XML string (e.g. upload it to a server):
 
 ```js
 QUnit.jUnitReport = function(report) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 	},
 	"keywords": [
 		"qunit",
-		"addon",
+		"plugin",
 		"reporter",
 		"junit"
 	],


### PR DESCRIPTION
In accordance with the decision made at the last QUnit team meeting, we will now be referring to "addons" as "plugins" from now on.
