### PR TITLE
multiple current tests and meaningful module name

### DIFF
--- a/qunit-reporter-junit.js
+++ b/qunit-reporter-junit.js
@@ -257,7 +257,7 @@
 			tests: run.total,
 			failures: run.failed,
 			errors: 0,
-			time: convertMillisToSeconds(run.time),  // ms â†’ sec
+			time: convertMillisToSeconds(run.time),  // ms → sec
 			timestamp: toISODateString(run.start)
 		});
 
@@ -271,7 +271,7 @@
 				tests: module.total,
 				failures: module.failed,
 				errors: 0,
-				time: convertMillisToSeconds(module.time),  // ms â†’ sec
+				time: convertMillisToSeconds(module.time),  // ms → sec
 				timestamp: toISODateString(module.start)
 			});
 
@@ -283,7 +283,7 @@
 					tests: test.total,
 					failures: test.failed,
 					errors: 0,
-					time: convertMillisToSeconds(test.time),  // ms â†’ sec
+					time: convertMillisToSeconds(test.time),  // ms → sec
 					timestamp: toISODateString(test.start)
 				});
 

--- a/qunit-reporter-junit.js
+++ b/qunit-reporter-junit.js
@@ -32,20 +32,18 @@
 	function getUsefulModuleName(dataName) {
 		try {
 			if(dataName === undefined) {
-				var i = location.pathname.lastIndexOf("/");
+				var i = location.pathname.lastIndexOf('/');
 				var name = location.pathname.substring(i + 1, location.pathname.length);
-				i = name.indexOf(".html", name.length - ".html".length);
+				i = name.indexOf('.html', name.length - '.html'.length);
 				if(i !== -1) {
 					name = name.substring(0, i);
 				}
 				return name;
 			}
-		} catch(e) {
-			
-		}
+		} catch(e) {}
 		return dataName;
 	}
-	
+
 	QUnit.moduleStart(function(data) {
 		currentModule = {
 			name: getUsefulModuleName(data.name),

--- a/qunit-reporter-junit.js
+++ b/qunit-reporter-junit.js
@@ -34,18 +34,16 @@
 			if(dataName === undefined) {
 				var i = location.pathname.lastIndexOf("/");
 				var name = location.pathname.substring(i + 1, location.pathname.length);
-				i = name.indexOf(".html", name.length - ".html".length);
+				i = name.indexOf('.html', name.length - '.html'.length);
 				if(i !== -1) {
 					name = name.substring(0, i);
 				}
 				return name;
 			}
-		} catch(e) {
-			
-		}
+		} catch(e) {}
 		return dataName;
 	}
-	
+
 	QUnit.moduleStart(function(data) {
 		currentModule = {
 			name: getUsefulModuleName(data.name),

--- a/qunit-reporter-junit.js
+++ b/qunit-reporter-junit.js
@@ -11,7 +11,7 @@
 
 	'use strict';
 
-	var currentRun, currentModule, currentTest, assertCount;
+	var currentRun, currentModule, currentTest = {}, assertCount;
 
 	// Gets called when a report is generated.
 	QUnit.jUnitReport = function(/* data */) {
@@ -29,9 +29,26 @@
 		};
 	});
 
+	function getUsefulModuleName(dataName) {
+		try {
+			if(dataName === undefined) {
+				var i = location.pathname.lastIndexOf("/");
+				var name = location.pathname.substring(i + 1, location.pathname.length);
+				i = name.indexOf(".html", name.length - ".html".length);
+				if(i !== -1) {
+					name = name.substring(0, i);
+				}
+				return name;
+			}
+		} catch(e) {
+			
+		}
+		return dataName;
+	}
+	
 	QUnit.moduleStart(function(data) {
 		currentModule = {
-			name: data.name,
+			name: getUsefulModuleName(data.name),
 			tests: [],
 			total: 0,
 			passed: 0,
@@ -46,10 +63,9 @@
 	});
 
 	QUnit.testStart(function(data) {
-		// Setup default module if no module was specified
 		if (!currentModule) {
 			currentModule = {
-				name: data.module || 'default',
+				name: getUsefulModuleName() || 'default',
 				tests: [],
 				total: 0,
 				passed: 0,
@@ -66,7 +82,7 @@
 		// Reset the assertion count
 		assertCount = 0;
 
-		currentTest = {
+		currentTest[data.name] = {
 			name: data.name,
 			failedAssertions: [],
 			total: 0,
@@ -76,28 +92,27 @@
 			time: 0
 		};
 
-		currentModule.tests.push(currentTest);
+		currentModule.tests.push(currentTest[data.name]);
 	});
 
 	QUnit.log(function(data) {
 		assertCount++;
-
 		// Ignore passing assertions
 		if (!data.result) {
-			currentTest.failedAssertions.push(data);
+			currentTest[data.name].failedAssertions.push(data);
 
 			// Add log message of failure to make it easier to find in Jenkins CI
-			currentModule.stdout.push('[' + currentModule.name + ', ' + currentTest.name + ', ' + assertCount + '] ' + data.message);
+			currentModule.stdout.push('[' + currentModule.name + ', ' + data.name + ', ' + assertCount + '] ' + data.message);
 		}
 	});
 
 	QUnit.testDone(function(data) {
-		currentTest.time = (new Date()).getTime() - currentTest.start.getTime();  // ms
-		currentTest.total = data.total;
-		currentTest.passed = data.passed;
-		currentTest.failed = data.failed;
-
-		currentTest = null;
+		var t = currentTest[data.name];
+		delete currentTest[data.name];
+		t.time = (new Date()).getTime() - t.start.getTime();  // ms
+		t.total = data.total;
+		t.passed = data.passed;
+		t.failed = data.failed;
 	});
 
 	QUnit.moduleDone(function(data) {
@@ -242,7 +257,7 @@
 			tests: run.total,
 			failures: run.failed,
 			errors: 0,
-			time: convertMillisToSeconds(run.time),  // ms → sec
+			time: convertMillisToSeconds(run.time),  // ms â†’ sec
 			timestamp: toISODateString(run.start)
 		});
 
@@ -256,7 +271,7 @@
 				tests: module.total,
 				failures: module.failed,
 				errors: 0,
-				time: convertMillisToSeconds(module.time),  // ms → sec
+				time: convertMillisToSeconds(module.time),  // ms â†’ sec
 				timestamp: toISODateString(module.start)
 			});
 
@@ -268,7 +283,7 @@
 					tests: test.total,
 					failures: test.failed,
 					errors: 0,
-					time: convertMillisToSeconds(test.time),  // ms → sec
+					time: convertMillisToSeconds(test.time),  // ms â†’ sec
 					timestamp: toISODateString(test.start)
 				});
 


### PR DESCRIPTION
Hi,

We ran across this issue when we tried to use qunit-reporter-junit with phantomjs and asynchronous tests.
It seems there is a legal case where the testStart callback is called for several tests in a row although although the prior one hasn't ended yet so I basically extended the currentTest variable to be a dictionary of current tests. This solved the problem for us.
I also implemented a method that tries to provide a meaningful modul name in case the test doesn't provide one, which makes it better for some cases and at least not worse for others.

regards

Reinhold
