### PR TITLE
Fixed bug preventing to work on Node.js

### DIFF
--- a/qunit-reporter-junit.js
+++ b/qunit-reporter-junit.js
@@ -237,7 +237,7 @@
 			});
 
 		xmlWriter.start('testsuites', {
-			name: (window && window.location && window.location.href) || (run.modules.length === 1 && run.modules[0].name) || null,
+			name: (typeof window != 'undefined' && window.location && window.location.href) || (run.modules.length === 1 && run.modules[0].name) || null,
 			hostname: 'localhost',
 			tests: run.total,
 			failures: run.failed,

--- a/qunit-reporter-junit.js
+++ b/qunit-reporter-junit.js
@@ -237,7 +237,7 @@
 			});
 
 		xmlWriter.start('testsuites', {
-			name: (typeof window != 'undefined' && window.location && window.location.href) || (run.modules.length === 1 && run.modules[0].name) || null,
+			name: (typeof window !== 'undefined' && window.location && window.location.href) || (run.modules.length === 1 && run.modules[0].name) || null,
 			hostname: 'localhost',
 			tests: run.total,
 			failures: run.failed,

--- a/qunit-reporter-junit.js
+++ b/qunit-reporter-junit.js
@@ -237,7 +237,7 @@
 			});
 
 		xmlWriter.start('testsuites', {
-			name: (typeof window !== 'undefined' && window.location && window.location.href) || (run.modules.length === 1 && run.modules[0].name) || null,
+			name: (typeof location !== 'undefined' && location.href) || (run.modules.length === 1 && run.modules[0].name) || null,
 			hostname: 'localhost',
 			tests: run.total,
 			failures: run.failed,


### PR DESCRIPTION
```window``` is not defined in Node.js, checking its type instead of it exists is safer and allow to use the plugin from command line.