### PR TITLE
Fixed Bug That Prevented Modules From having The Same Test Name(s)

### DIFF
--- a/qunit-reporter-junit.js
+++ b/qunit-reporter-junit.js
@@ -8,6 +8,7 @@
  * https://jquery.org/license/
  */
 (function() {
+	
 	'use strict';
 
 	var currentRun, currentModule, currentTest = {}, assertCount;


### PR DESCRIPTION
- I have fixed a bug that prevented the developer from have the same test name in two different modules 
- I have integrated the changes from pull 9 and incorporated the feedback given in pull 9's comments 
