### PR TITLE
Removed attributes no longer valid so that results file can be parsed by xunit

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -3,3 +3,4 @@ Johan Sörlin <spocke@moxiecode.com>
 Jonathan Sanchez <jsanchezpando@cirb.irisnet.be>
 Timo Tijhof <krinklemail@gmail.com>
 James M. Greene <james.m.greene@gmail.com>
+Lachlan Barclay <clockwise.music@gmail.com>

--- a/qunit-reporter-junit.js
+++ b/qunit-reporter-junit.js
@@ -238,12 +238,10 @@
 
 		xmlWriter.start('testsuites', {
 			name: (window && window.location && window.location.href) || (run.modules.length === 1 && run.modules[0].name) || null,
-			hostname: 'localhost',
 			tests: run.total,
 			failures: run.failed,
 			errors: 0,
-			time: convertMillisToSeconds(run.time),  // ms → sec
-			timestamp: toISODateString(run.start)
+			time: convertMillisToSeconds(run.time)  // ms → sec
 		});
 
 		for (m = 0, mLen = run.modules.length; m < mLen; m++) {
@@ -265,9 +263,6 @@
 
 				xmlWriter.start('testcase', {
 					name: test.name,
-					tests: test.total,
-					failures: test.failed,
-					errors: 0,
 					time: convertMillisToSeconds(test.time),  // ms → sec
 					timestamp: toISODateString(test.start)
 				});

--- a/test/expected.xml
+++ b/test/expected.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="http://localhost:8000/test/index.html" hostname="localhost" tests="10" failures="5" errors="0" time="0.02" timestamp="2013-03-12T13:11:50Z">
+<testsuites name="http://localhost:8000/test/index.html" tests="10" failures="5" errors="0" time="0.02">
 <testsuite id="0" name="Module 1" hostname="localhost" tests="5" failures="2" errors="0" time="0.004" timestamp="2013-03-12T13:11:50Z">
-<testcase name="test 1" tests="2" failures="1" errors="0" time="0.003" timestamp="2013-03-12T13:11:50Z">
+<testcase name="test 1" time="0.003" timestamp="2013-03-12T13:11:50Z">
 <failure type="AssertionFailedError" message="Assert fail 1 = 2">
 <actual value="1" /><expected value="2" />
 </failure>
 </testcase>
-<testcase name="test 2" tests="3" failures="1" errors="0" time="0.001" timestamp="2013-03-12T13:11:50Z">
+<testcase name="test 2" time="0.001" timestamp="2013-03-12T13:11:50Z">
 <failure type="AssertionFailedError" message="Assert fail 1 = 2">
 <actual value="1" /><expected value="2" />
 </failure>
@@ -19,12 +19,12 @@
 </system-out>
 </testsuite>
 <testsuite id="1" name="Module 2" hostname="localhost" tests="5" failures="3" errors="0" time="0.001" timestamp="2013-03-12T13:11:50Z">
-<testcase name="test 3" tests="2" failures="1" errors="0" time="0" timestamp="2013-03-12T13:11:50Z">
+<testcase name="test 3" time="0" timestamp="2013-03-12T13:11:50Z">
 <failure type="AssertionFailedError" message="Assert fail 1 = 2">
 <actual value="1" /><expected value="2" />
 </failure>
 </testcase>
-<testcase name="test 4" tests="3" failures="2" errors="0" time="0.001" timestamp="2013-03-12T13:11:50Z">
+<testcase name="test 4" time="0.001" timestamp="2013-03-12T13:11:50Z">
 <failure type="AssertionFailedError" message="Assert fail 1 = 2">
 <actual value="1" /><expected value="2" />
 </failure>


### PR DESCRIPTION
While trying to parse the results file using xUnit (https://wiki.jenkins-ci.org/display/JENKINS/xUnit+Plugin) I got an error on a few attributes. It seems like these attributes are no longer valid, so removing them from the generated file fixes the problem.